### PR TITLE
catch-all route

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 const express = require('express')
 const dotenv = require('dotenv')
 const connectDb = require('./database/db')
+const path = require('path')
 
 dotenv.config()
 
@@ -9,6 +10,14 @@ app.use(express.json())
 app.use(express.static('public'));
 
 connectDb();
+
+//
+// Route för att fånga allt som inte redan har processats av tidigare routes.
+// Detta för att få react-routern att fungera på klientsidan.
+// Alla andra routes ska ligga _före_ denna, dvs denna ligger alltid sist.
+app.get('*', (req,res) => {
+    res.sendFile(path.join(__dirname, '../public/index.html'));
+});
 
 const PORT = process.env.PORT || 5000
 app.listen(PORT, () => {


### PR DESCRIPTION
Mindre fix för att se till att klient-side routing fungerar som tänkt. Har lagt till en route som fångar "allt" och renderar react-applikationen istället.